### PR TITLE
Add CSP meta fallback and security header guidance

### DIFF
--- a/SECURITY_HEADERS.md
+++ b/SECURITY_HEADERS.md
@@ -1,0 +1,29 @@
+# Security Headers
+
+This site now embeds a minimal [Content Security Policy](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy) via a `<meta http-equiv>` tag so browsers on hosts that don't yet set HTTP headers can still apply a safe default:
+
+```
+default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' https: data:;
+```
+
+The same policy, along with other recommended headers, is recorded in [`security-headers.conf`](security-headers.conf) and should be served as real HTTP response headers:
+
+```
+Content-Security-Policy-Report-Only: default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' https: data:;
+X-Content-Type-Options: nosniff
+Referrer-Policy: strict-origin-when-cross-origin
+Permissions-Policy: camera=(), microphone=(), geolocation=()
+```
+
+## Enabling headers on GitHub Pages via Cloudflare
+
+GitHub Pages does not support custom security headers, so use Cloudflare (or another CDN) in front of the site to inject them:
+
+1. Add the `vahorizon.site` domain to Cloudflare and enable the orange cloud proxy for the `www` DNS record.
+2. Navigate to **Rules → Transform Rules → Modify Response Header** and add the headers above. Start the CSP as `Content-Security-Policy-Report-Only` to monitor violations.
+3. After confirming the policy is clean, change it to `Content-Security-Policy` (enforcing) and optionally remove the meta tag fallback.
+4. Repeat the same steps for any additional subdomains.
+
+## SecurityHeaders.com results
+
+The site currently scores **F** on [SecurityHeaders.com](https://securityheaders.com/?q=www.vahorizon.site&followRedirects=on) because the host does not yet send these headers. After enabling them at the CDN, re-run the scan to verify the grade improves.

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     </noscript>
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' https: data:;">
     <meta name="color-scheme" content="light dark">
     <link rel="canonical" href="https://www.vahorizon.site/">
 

--- a/offline.html
+++ b/offline.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' https: data:;">
   <title>Offline</title>
   <style>
     body { font-family: sans-serif; text-align: center; padding: 2rem; }


### PR DESCRIPTION
## Summary
- embed CSP fallback meta tag for hosts without header support
- document recommended security headers and how to enable them on GitHub Pages via Cloudflare

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -s https://securityheaders.com/?q=www.vahorizon.site&followRedirects=on | head -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68af2d49590c832b81dd815ed15e9279