### PR TITLE
feat: implement typographic scale and optimize text

### DIFF
--- a/VAHorizonWebsiteStyle/_components/v1/93bdfffda6e0bf9a7fd91429ea912af65458e738.css
+++ b/VAHorizonWebsiteStyle/_components/v1/93bdfffda6e0bf9a7fd91429ea912af65458e738.css
@@ -5164,3 +5164,34 @@ html {
     opacity: 0;
   }
 }
+
+:root {
+  --step--2: 0.64rem;
+  --step--1: 0.8rem;
+  --step-0: 1rem;
+  --step-1: 1.25rem;
+  --step-2: 1.563rem;
+  --step-3: 1.953rem;
+  --rhythm: 1.5rem;
+}
+
+body {
+  font-size: var(--step-0);
+  line-height: 1.5;
+  font-optical-sizing: auto;
+  font-feature-settings: 'liga','calt','kern';
+  max-width: 75ch;
+  margin-inline: auto;
+  padding-inline: 1rem;
+}
+
+h1, h2, h3, h4, h5, h6, p {
+  margin-block: 0 var(--rhythm);
+}
+
+h1 { font-size: var(--step-3); }
+h2 { font-size: var(--step-2); }
+h3 { font-size: var(--step-1); }
+h4 { font-size: var(--step-0); }
+h5 { font-size: var(--step--1); }
+h6 { font-size: var(--step--2); }


### PR DESCRIPTION
## Summary
- define CSS custom property type scale and apply to headings and body
- enable font optical sizing and OpenType features for better rendering
- constrain body line length and spacing for more consistent rhythm

## Testing
- `npm run lint`
- Contrast ratio of black text on white background: 21.00


------
https://chatgpt.com/codex/tasks/task_b_68af3ccce3f4832b8eb9e711132ad703