### PR TITLE
Fix: prevent Tailwind container from compressing layout + bust cache

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,14 +174,20 @@
       }
     }
     </style>
-    <link rel="preload" href="VAHorizonWebsiteStyle/_components/v1/93bdfffda6e0bf9a7fd91429ea912af65458e738.css" as="style" onload="this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="VAHorizonWebsiteStyle/_components/v1/93bdfffda6e0bf9a7fd91429ea912af65458e738.css"></noscript>
+    <link rel="preload" href="VAHorizonWebsiteStyle/_components/v1/93bdfffda6e0bf9a7fd91429ea912af65458e738.css?v=3" as="style" onload="this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="VAHorizonWebsiteStyle/_components/v1/93bdfffda6e0bf9a7fd91429ea912af65458e738.css?v=3"></noscript>
 
     
     
     <script data-template-id="country-code">window.__cf_country = "EG"</script>
         
-    <link rel="stylesheet" href="cards.css">
+    <link rel="stylesheet" href="cards.css?v=3">
+    <style id="container-fix">
+      .container {
+        max-width: 100% !important;
+        width: 100% !important;
+      }
+    </style>
       <style id="layout-unsquish">
         /* 0) Correct mobile viewport if missing */
         @supports (width: 100dvw) {


### PR DESCRIPTION
## Summary
- override Tailwind's `.container` to always span the full width
- bust CSS cache references so browsers fetch updated styles

## Testing
- `node -e 'const {JSDOM}=require("jsdom"); const html=`<style>.container{max-width:100% !important;width:100% !important;}</style><div id="container" class="container"></div>`; const dom=new JSDOM(html,{pretendToBeVisual:true}); const {window}=dom; const el=window.document.querySelector("#container"); console.log("window.innerWidth", window.innerWidth); console.log("#container width", el.getBoundingClientRect().width); console.log("computed maxWidth", window.getComputedStyle(el).maxWidth);'`

------
https://chatgpt.com/codex/tasks/task_b_68af5da70084832b843dbd90c06f8b35