### PR TITLE
Replace header and footer logos with composite images

### DIFF
--- a/buttons.js
+++ b/buttons.js
@@ -4,6 +4,19 @@ document.addEventListener('DOMContentLoaded', () => {
   const init = () => {
   const calendlyURL = 'https://calendly.com/youssef-vahorizon/30min';
 
+  // Replace logos in header and footer with provided composite images
+  const logoMarkup = `
+    <img src="/logo.png" alt="VA Horizon logo" class="h-8 w-8">
+    <div class="flex flex-col leading-none">
+      <img src="/va-horizon.png" alt="VA Horizon" class="h-3 md:h-4">
+      <img src="/tagline.png" alt="Trained Virtual Assistants" class="h-2 md:h-3">
+    </div>
+  `;
+  ['header', 'footer'].forEach(section => {
+    const container = document.querySelector(`${section} .flex.items-center.space-x-2`);
+    if (container) container.innerHTML = logoMarkup;
+  });
+
   // Inject hover animation styles for interactive elements
   const hoverStyle = document.createElement('style');
   hoverStyle.textContent = `


### PR DESCRIPTION
## Summary
- Replace header and footer logos with composite of `logo.png`, `va-horizon.png`, and `tagline.png`
- Inject images via script so both header and footer show the new branding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68af70bfafa8832bad7169419fc6fcf6