### PR TITLE
Use navy styling for secondary buttons

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -145,10 +145,11 @@ textarea:focus-visible {
 .btn-primary:focus-visible{ outline: 3px solid rgba(199,155,36,.45); outline-offset:2px; }
 
 .btn-secondary{
-  background: transparent; color: var(--va-navy, #0b1220);
+  background: var(--va-navy);
+  color: var(--va-navy-contrast);
   border: 1px solid var(--va-gold, #c79b24);
 }
-.btn-secondary:hover{ background: rgba(199,155,36,.08); }
+.btn-secondary:hover{ background: var(--va-navy); color: var(--va-navy-contrast); }
 .btn-secondary:focus-visible{ outline: 3px solid rgba(199,155,36,.35); outline-offset:2px; }
 
 .btn > svg, .btn > img.icon { width: 1.1em; height: 1.1em; flex: 0 0 auto; }


### PR DESCRIPTION
## Summary
- style `.btn-secondary` with VA navy background and contrasting text
- keep gold border accent and remove light hover fade

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b1a5e897f8832bb2385575fa21ccd2