### PR TITLE
fix: restore card borders and refresh cache

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -6,7 +6,7 @@
   --va-gold-strong: #A17E1F;  /* darker gold for text on white if needed */
   --card-radius: 16px;
   --card-padding: 24px;
-  --card-border: 1px solid rgba(11,18,32,.08);
+  --card-border: 1px solid var(--va-divider);
   --shadow-xs: 0 1px 2px rgba(11,18,32,.08), 0 0 0 1px rgba(11,18,32,.04) inset;
   --shadow-s: 0 4px 10px rgba(11,18,32,.08);
   --shadow-m: 0 10px 24px rgba(11,18,32,.12);

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@ importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox
 workbox.core.skipWaiting();
 workbox.core.clientsClaim();
 
-const CACHE_VERSION = 'v2';
+const CACHE_VERSION = 'v3';
 
 workbox.precaching.precacheAndRoute([
   { url: '/', revision: CACHE_VERSION },


### PR DESCRIPTION
## Summary
- restore visible card borders using shared divider color
- bump service worker cache version to refresh styles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b1fb2fc484832bb948d48865ef52fd