### PR TITLE
Align service card buttons

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -189,3 +189,20 @@ textarea:focus-visible {
 .hero .dashboard {
   filter: drop-shadow(0 16px 24px rgba(11,18,32,.25));
 }
+
+/* Align service card buttons */
+#services .card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+#services .card__body {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+#services .card__body .btn {
+  margin-top: auto;
+}


### PR DESCRIPTION
## Summary
- Ensure service cards flex vertically so "Learn More" buttons align at the bottom across columns.

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b1ffe99f28832b98bf85daeeb1794b