### PR TITLE
feat: add standalone VA dashboard widget

### DIFF
--- a/va-dashboard.css
+++ b/va-dashboard.css
@@ -1,0 +1,202 @@
+.va-dashboard {
+  --va-gold: #cfae70;
+  --va-blue: #0e3a5b;
+  --va-text: #101828;
+  --va-muted: #667085;
+  --va-bg: #ffffff;
+  --va-row: #f4f5f7;
+  --va-border: #e6e8ec;
+  --va-shadow: 0 18px 40px rgba(16, 24, 40, 0.12);
+  --va-glow: 0 0 0 6px rgba(207, 174, 112, 0.14);
+  color: var(--va-text);
+  background: var(--va-bg);
+  border: 1px solid var(--va-border);
+  border-radius: 16px;
+  padding: 20px 24px;
+  box-shadow: var(--va-shadow);
+  position: relative;
+  max-width: 640px;
+  font-feature-settings: "tnum" 1, "ss01" 1;
+}
+
+.va-dash__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.va-dash__traffic {
+  display: flex;
+  gap: 8px;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  display: inline-block;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.15) inset;
+}
+
+.dot--red {
+  background: #ff5f57;
+}
+
+.dot--yellow {
+  background: #febc2e;
+}
+
+.dot--green {
+  background: #28c840;
+}
+
+.va-dash__title {
+  margin-left: auto;
+  color: var(--va-muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.va-dash__live {
+  position: absolute;
+  top: -12px;
+  right: -8px;
+  background: var(--va-gold);
+  color: #1b1b1b;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 8px 14px;
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(207, 174, 112, 0.4);
+}
+
+.va-dash__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 12px;
+  margin-bottom: 14px;
+  border-bottom: 1px solid #eef0f3;
+}
+
+.va-dash__select {
+  height: 40px;
+  border: 1px solid var(--va-border);
+  border-radius: 10px;
+  background: #fff;
+  padding: 0 12px;
+  min-width: 220px;
+}
+
+.va-dash__select:focus {
+  outline: none;
+  border-color: var(--va-gold);
+  box-shadow: var(--va-glow);
+}
+
+.va-dash__status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--va-muted);
+  font-size: 12px;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 99px;
+  background: #12b76a;
+  box-shadow: 0 0 0 3px rgba(18, 183, 106, 0.12);
+}
+
+.va-dash__notice {
+  background: #fef3c7;
+  color: #b45309;
+  font-size: 12px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  margin-bottom: 12px;
+}
+
+.va-dash__list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.kpi {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.35),
+      rgba(255, 255, 255, 0)
+    ),
+    var(--va-row);
+  padding: 16px 18px;
+  border-radius: 12px;
+  transform: translateY(0);
+  opacity: 1;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.kpi__label {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--va-text);
+}
+
+.kpi__value {
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--va-blue);
+}
+
+.kpi__value--gold {
+  color: var(--va-gold);
+}
+
+.kpi.is-leaving {
+  transform: translateY(14px);
+  opacity: 0;
+}
+
+.kpi.is-entering {
+  transform: translateY(-14px);
+  opacity: 0;
+}
+
+.kpi.is-entering.is-entered {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.va-dash__va-bubble {
+  position: absolute;
+  left: -6px;
+  bottom: -10px;
+  background: #fff;
+  border: 1px solid var(--va-border);
+  border-radius: 10px;
+  padding: 8px 12px;
+  box-shadow: 0 12px 20px rgba(16, 24, 40, 0.12);
+}
+
+.sr-only {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/va-dashboard.data.json
+++ b/va-dashboard.data.json
@@ -1,0 +1,12 @@
+{
+  "date": "2025-08-28",
+  "items": [
+    { "id": "ahmed-hassan", "name": "Ahmed Hassan", "online": true,  "updatedAt": "2025-08-28T14:02:00Z", "metrics": { "coldCalls": 16, "appointmentsSet": 12, "listsProcessed": 10 } },
+    { "id": "samir-khaled", "name": "Samir Khaled", "online": true,  "updatedAt": "2025-08-28T14:02:00Z", "metrics": { "coldCalls": 11, "appointmentsSet": 7,  "listsProcessed": 8 } },
+    { "id": "maria-diaz",   "name": "Maria Diaz",   "online": false, "updatedAt": "2025-08-28T14:02:00Z", "metrics": { "coldCalls": 24, "appointmentsSet": 14, "listsProcessed": 13 } },
+    { "id": "noah-carter",  "name": "Noah Carter",  "online": true,  "updatedAt": "2025-08-28T14:02:00Z", "metrics": { "coldCalls": 19, "appointmentsSet": 9,  "listsProcessed": 12 } },
+    { "id": "liam-chen",    "name": "Liam Chen",    "online": true,  "updatedAt": "2025-08-28T14:02:00Z", "metrics": { "coldCalls": 21, "appointmentsSet": 11, "listsProcessed": 9 } },
+    { "id": "sofia-rossi",  "name": "Sofia Rossi",  "online": false, "updatedAt": "2025-08-28T14:02:00Z", "metrics": { "coldCalls": 17, "appointmentsSet": 8,  "listsProcessed": 11 } },
+    { "id": "emma-patel",   "name": "Emma Patel",   "online": true,  "updatedAt": "2025-08-28T14:02:00Z", "metrics": { "coldCalls": 13, "appointmentsSet": 6,  "listsProcessed": 7 } }
+  ]
+}

--- a/va-dashboard.html
+++ b/va-dashboard.html
@@ -1,0 +1,40 @@
+<section class="va-dashboard" role="region" aria-label="VA Live Dashboard">
+  <header class="va-dash__header">
+    <div class="va-dash__traffic">
+      <span class="dot dot--red" aria-hidden="true"></span>
+      <span class="dot dot--yellow" aria-hidden="true"></span>
+      <span class="dot dot--green" aria-hidden="true"></span>
+    </div>
+    <div class="va-dash__title">VA Dashboard</div>
+    <span class="va-dash__live" aria-live="polite">Live Now</span>
+  </header>
+
+  <div class="va-dash__toolbar">
+    <label class="sr-only" for="va-picker">Select Virtual Assistant</label>
+    <select id="va-picker" class="va-dash__select" aria-describedby="va-picker-help"></select>
+
+    <div class="va-dash__status">
+      <span class="status-dot" aria-hidden="true"></span>
+      <span class="status-label" id="va-picker-help">Updated just now</span>
+    </div>
+  </div>
+
+  <div class="va-dash__notice" role="status" aria-live="polite" hidden></div>
+
+  <ul class="va-dash__list" aria-live="polite" aria-atomic="true">
+    <li class="kpi" data-key="coldCalls">
+      <span class="kpi__label">Cold Calls Today</span>
+      <span class="kpi__value" data-value>0</span>
+    </li>
+    <li class="kpi" data-key="appointmentsSet">
+      <span class="kpi__label">Appointments Set</span>
+      <span class="kpi__value kpi__value--gold" data-value>0</span>
+    </li>
+    <li class="kpi" data-key="listsProcessed">
+      <span class="kpi__label">Lists Processed</span>
+      <span class="kpi__value" data-value>0</span>
+    </li>
+  </ul>
+
+  <div class="va-dash__va-bubble" aria-hidden="true" style="display:none">Your VA: <span data-va-name></span></div>
+</section>

--- a/va-dashboard.js
+++ b/va-dashboard.js
@@ -1,0 +1,194 @@
+class VADashboard {
+  constructor(
+    rootEl,
+    {
+      dataUrl = '/api/va-stats',
+      fallbackUrl = 'va-dashboard.data.json',
+      pollMs = 60000
+    } = {}
+  ) {
+    this.root = rootEl;
+    this.dataUrl = dataUrl;
+    this.fallbackUrl = fallbackUrl;
+    this.pollMs = pollMs;
+    this.state = { items: [], selectedId: null };
+    this.etag = null;
+    this.timers = new Map();
+    this.backoff = pollMs;
+  }
+
+  async init() {
+    this.selectEl = this.root.querySelector('.va-dash__select');
+    this.statusDot = this.root.querySelector('.status-dot');
+    this.statusLabel = this.root.querySelector('.status-label');
+    this.noticeEl = this.root.querySelector('.va-dash__notice');
+    this.vaBubble = this.root.querySelector('.va-dash__va-bubble');
+    await this.loadData();
+    this.populateSelect();
+    const saved = localStorage.getItem('va-dashboard:selected');
+    if (saved && this.state.items.some((it) => it.id === saved)) {
+      this.state.selectedId = saved;
+    } else {
+      this.state.selectedId = this.state.items[0]?.id || null;
+    }
+    if (this.state.selectedId) {
+      this.selectEl.value = this.state.selectedId;
+      this.setSelected(this.state.selectedId, true);
+    }
+    this.selectEl.addEventListener('change', (e) => {
+      this.debounceSelect(() => this.setSelected(e.target.value));
+    });
+    this.startPolling();
+  }
+
+  populateSelect() {
+    this.selectEl.innerHTML = '';
+    this.state.items.forEach((item) => {
+      const opt = document.createElement('option');
+      opt.value = item.id;
+      opt.textContent = item.name;
+      this.selectEl.appendChild(opt);
+    });
+  }
+
+  debounceSelect(fn) {
+    clearTimeout(this.selectDebounce);
+    this.selectDebounce = setTimeout(fn, 50);
+  }
+
+  async loadData() {
+    try {
+      const res = await fetch(this.dataUrl, this.etag ? { headers: { 'If-None-Match': this.etag } } : {});
+      if (res.status === 304) {
+        this.hideNotice();
+        return;
+      }
+      if (!res.ok) {
+        throw new Error('Network');
+      }
+      this.etag = res.headers.get('ETag') || this.etag;
+      const data = await res.json();
+      this.state.items = data.items;
+      this.hideNotice();
+      this.backoff = this.pollMs;
+    } catch (e) {
+      if (!this.state.items.length) {
+        const res = await fetch(this.fallbackUrl);
+        const data = await res.json();
+        this.state.items = data.items;
+      }
+      this.showNotice('Offline—showing last known stats');
+      this.backoff = Math.min(this.backoff * 2, 300000);
+    }
+  }
+
+  setSelected(id, skipAnim = false) {
+    if (!id) return;
+    this.state.selectedId = id;
+    localStorage.setItem('va-dashboard:selected', id);
+    const item = this.state.items.find((it) => it.id === id);
+    if (!item) return;
+    this.statusDot.style.background = item.online ? '#12B76A' : '#98A2B3';
+    this.statusLabel.textContent = 'Updated just now';
+    this.vaBubble.querySelector('[data-va-name]').textContent = item.name;
+    this.vaBubble.style.display = 'block';
+    const list = this.root.querySelector('.va-dash__list');
+    const rows = list.querySelectorAll('.kpi');
+    if (!skipAnim) {
+      rows.forEach((li) => li.classList.add('is-leaving'));
+      setTimeout(() => {
+        rows.forEach((li) => li.classList.remove('is-leaving'));
+        rows.forEach((li) => li.classList.add('is-entering'));
+        requestAnimationFrame(() => {
+          rows.forEach((li) => li.classList.add('is-entered'));
+        });
+        setTimeout(() => {
+          rows.forEach((li) => li.classList.remove('is-entering', 'is-entered'));
+        }, 220);
+      }, 200);
+    }
+    const metrics = item.metrics;
+    rows.forEach((li) => {
+      const key = li.dataset.key;
+      const valueEl = li.querySelector('[data-value]');
+      const to = metrics[key] || 0;
+      const from = Number(valueEl.textContent) || 0;
+      if (skipAnim) {
+        valueEl.textContent = to;
+      } else {
+        this.animateValue(valueEl, from, to);
+      }
+    });
+  }
+
+  animateValue(el, from, to, duration = 450) {
+    const start = performance.now();
+    const ease = (t) => 1 - Math.pow(1 - t, 3);
+    const step = (now) => {
+      const progress = Math.min(1, (now - start) / duration);
+      const val = Math.round(from + (to - from) * ease(progress));
+      el.textContent = val;
+      if (progress < 1) {
+        const id = requestAnimationFrame(step);
+        this.timers.set(el, id);
+      } else {
+        this.timers.delete(el);
+      }
+    };
+    cancelAnimationFrame(this.timers.get(el));
+    const id = requestAnimationFrame(step);
+    this.timers.set(el, id);
+  }
+
+  async poll() {
+    if (document.visibilityState === 'hidden') {
+      this.schedulePoll();
+      return;
+    }
+    const prev = this.state.items.find((it) => it.id === this.state.selectedId);
+    await this.loadData();
+    const current = this.state.items.find((it) => it.id === this.state.selectedId);
+    if (prev && current) {
+      const changed =
+        current.metrics.coldCalls !== prev.metrics.coldCalls ||
+        current.metrics.appointmentsSet !== prev.metrics.appointmentsSet ||
+        current.metrics.listsProcessed !== prev.metrics.listsProcessed;
+      if (changed) {
+        this.setSelected(this.state.selectedId);
+      }
+    }
+    this.schedulePoll();
+  }
+
+  schedulePoll(interval = this.backoff) {
+    clearTimeout(this.pollTimer);
+    this.pollTimer = setTimeout(() => this.poll(), interval);
+  }
+
+  startPolling() {
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        this.poll();
+      }
+    });
+    this.schedulePoll();
+  }
+
+  showNotice(msg) {
+    if (!this.noticeEl) return;
+    this.noticeEl.textContent = msg;
+    this.noticeEl.hidden = false;
+  }
+
+  hideNotice() {
+    if (!this.noticeEl) return;
+    this.noticeEl.hidden = true;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.va-dashboard').forEach((el) => {
+    const dash = new VADashboard(el);
+    dash.init();
+  });
+});


### PR DESCRIPTION
## Summary
- add drop-in VA dashboard HTML markup
- style dashboard card with traffic lights, gold accents, and row animations
- implement JS for data polling, VA selection persistence, and KPI tweening
- provide sample VA stats seed data

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b2693e5c6c832ba6dc7bba7546292d