### PR TITLE
feat: add live VA dashboard widget

### DIFF
--- a/va-dashboard.css
+++ b/va-dashboard.css
@@ -1,0 +1,49 @@
+.va-dashboard {
+  --va-gold: #cfae70;
+  --va-blue: #0E3A5B;
+  --va-text: #101828;
+  --va-muted: #667085;
+  --va-bg: #ffffff;
+  --va-row: #F4F5F7;
+  --va-border: #E6E8EC;
+  --va-shadow: 0 18px 40px rgba(16, 24, 40, 0.12);
+  --va-glow: 0 0 0 6px rgba(207,174,112,.14);
+  color: var(--va-text);
+  background: var(--va-bg);
+  border: 1px solid var(--va-border);
+  border-radius: 16px;
+  padding: 20px 24px;
+  box-shadow: var(--va-shadow);
+  position: relative;
+  max-width: 640px;
+  font-feature-settings: "tnum" 1, "ss01" 1;
+}
+@media (max-width: 480px) {
+  .va-dashboard { padding: 16px; }
+}
+.va-dash__header{display:flex;align-items:center;gap:12px;margin-bottom:16px;}
+.va-dash__traffic{display:flex;gap:8px;}
+.dot{width:10px;height:10px;border-radius:999px;display:inline-block;box-shadow:0 1px 0 rgba(0,0,0,.15) inset;}
+.dot--red{background:#FF5F57;}
+.dot--yellow{background:#FEBC2E;}
+.dot--green{background:#28C840;}
+.va-dash__title{margin-left:auto;color:var(--va-muted);font-size:12px;font-weight:600;}
+.va-dash__live{position:absolute;top:-12px;right:-8px;background:var(--va-gold);color:#1B1B1B;font-size:12px;font-weight:600;padding:8px 14px;border-radius:10px;box-shadow:0 8px 24px rgba(207,174,112,.4);}
+.va-dash__toolbar{display:flex;align-items:center;justify-content:space-between;gap:12px;padding-bottom:12px;margin-bottom:14px;border-bottom:1px solid #EEF0F3;flex-wrap:wrap;}
+.va-dash__select{height:40px;border:1px solid var(--va-border);border-radius:10px;background:#fff;padding:0 12px;min-width:220px;}
+.va-dash__select:focus{outline:none;border-color:var(--va-gold);box-shadow:var(--va-glow);}
+.va-dash__status{display:flex;align-items:center;gap:8px;color:var(--va-muted);font-size:12px;}
+.status-dot{width:8px;height:8px;border-radius:99px;background:#12B76A;box-shadow:0 0 0 3px rgba(18,183,106,.12);transition:background .2s;}
+.status-dot.is-off{background:#98A2B3;box-shadow:0 0 0 3px rgba(152,162,179,.12);}
+.va-dash__notice{margin-bottom:12px;font-size:12px;padding:8px 12px;border-radius:8px;background:#FFF6E9;color:#B54708;border:1px solid #FEDF89;}
+.va-dash__list{display:flex;flex-direction:column;gap:14px;list-style:none;margin:0;padding:0;}
+.kpi{display:flex;align-items:center;justify-content:space-between;background:linear-gradient(to bottom, rgba(255,255,255,.35), rgba(255,255,255,0)), var(--va-row);padding:16px 18px;border-radius:12px;transform:translateY(0);opacity:1;transition:transform .2s ease, opacity .2s ease;}
+.kpi.is-leaving{transform:translateY(14px);opacity:0;}
+.kpi.is-entering{transform:translateY(-14px);opacity:0;}
+.kpi.is-entering.is-entered{transform:translateY(0);opacity:1;}
+.kpi__label{font-size:16px;font-weight:600;color:var(--va-text);}
+.kpi__value{font-size:22px;font-weight:800;color:var(--va-blue);}
+.kpi__value--gold{color:var(--va-gold);}
+.va-dash__va-bubble{position:absolute;left:-6px;bottom:-10px;background:#fff;border:1px solid var(--va-border);border-radius:10px;padding:8px 12px;box-shadow:0 12px 20px rgba(16,24,40,.12);font-size:12px;display:none;}
+.va-dash__va-bubble.is-visible{display:block;}
+.sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}

--- a/va-dashboard.data.json
+++ b/va-dashboard.data.json
@@ -1,0 +1,11 @@
+{
+  "date": "2025-08-28",
+  "items": [
+    { "id": "ahmed-hassan", "name": "Ahmed Hassan", "online": true,  "updatedAt": "2025-08-28T14:02:00Z", "metrics": { "coldCalls": 16, "appointmentsSet": 12, "listsProcessed": 10 } },
+    { "id": "samir-khaled", "name": "Samir Khaled", "online": true,  "updatedAt": "2025-08-28T14:02:00Z", "metrics": { "coldCalls": 11, "appointmentsSet": 7,  "listsProcessed": 8 } },
+    { "id": "maria-diaz",   "name": "Maria Diaz",   "online": false, "updatedAt": "2025-08-28T14:02:00Z", "metrics": { "coldCalls": 24, "appointmentsSet": 14, "listsProcessed": 13 } },
+    { "id": "noah-carter",  "name": "Noah Carter",  "online": true,  "updatedAt": "2025-08-28T14:02:00Z", "metrics": { "coldCalls": 19, "appointmentsSet": 9,  "listsProcessed": 12 } },
+    { "id": "liam-chen",    "name": "Liam Chen",    "online": false, "updatedAt": "2025-08-28T14:02:00Z", "metrics": { "coldCalls": 9,  "appointmentsSet": 5,  "listsProcessed": 7 } },
+    { "id": "sofia-rossi",  "name": "Sofia Rossi",  "online": true,  "updatedAt": "2025-08-28T14:02:00Z", "metrics": { "coldCalls": 22, "appointmentsSet": 17, "listsProcessed": 15 } }
+  ]
+}

--- a/va-dashboard.html
+++ b/va-dashboard.html
@@ -1,0 +1,40 @@
+<section class="va-dashboard" role="region" aria-label="VA Live Dashboard">
+  <header class="va-dash__header">
+    <div class="va-dash__traffic">
+      <span class="dot dot--red" aria-hidden="true"></span>
+      <span class="dot dot--yellow" aria-hidden="true"></span>
+      <span class="dot dot--green" aria-hidden="true"></span>
+    </div>
+    <div class="va-dash__title">VA Dashboard</div>
+    <span class="va-dash__live" aria-live="polite">Live Now</span>
+  </header>
+
+  <div class="va-dash__toolbar">
+    <label class="sr-only" for="va-picker">Select Virtual Assistant</label>
+    <select id="va-picker" class="va-dash__select" aria-describedby="va-picker-help"></select>
+
+    <div class="va-dash__status">
+      <span class="status-dot" aria-hidden="true"></span>
+      <span class="status-label" id="va-picker-help">Updated just now</span>
+    </div>
+  </div>
+
+  <div class="va-dash__notice" role="status" aria-live="polite" hidden></div>
+
+  <ul class="va-dash__list" aria-live="polite" aria-atomic="true">
+    <li class="kpi" data-key="coldCalls">
+      <span class="kpi__label">Cold Calls Today</span>
+      <span class="kpi__value" data-value>0</span>
+    </li>
+    <li class="kpi" data-key="appointmentsSet">
+      <span class="kpi__label">Appointments Set</span>
+      <span class="kpi__value kpi__value--gold" data-value>0</span>
+    </li>
+    <li class="kpi" data-key="listsProcessed">
+      <span class="kpi__label">Lists Processed</span>
+      <span class="kpi__value" data-value>0</span>
+    </li>
+  </ul>
+
+  <div class="va-dash__va-bubble" aria-hidden="true">Your VA: <span data-va-name></span></div>
+</section>

--- a/va-dashboard.js
+++ b/va-dashboard.js
@@ -1,0 +1,192 @@
+class VADashboard {
+  constructor(rootEl, { dataUrl = '/api/va-stats', fallbackUrl = 'va-dashboard.data.json', pollMs = 60000 } = {}) {
+    this.root = rootEl;
+    this.dataUrl = dataUrl;
+    this.fallbackUrl = fallbackUrl;
+    this.pollMs = pollMs;
+    this.state = { items: [], selectedId: null };
+    this.animations = new Map();
+    this.etag = null;
+    this.noticeEl = rootEl.querySelector('.va-dash__notice');
+    this.pollTimer = null;
+  }
+
+  async init() {
+    await this.loadData();
+    if (!this.state.items.length) return;
+    const select = this.root.querySelector('.va-dash__select');
+    const saved = localStorage.getItem('va-dashboard:selected');
+    if (saved && this.state.items.find(i => i.id === saved)) {
+      select.value = saved;
+      this.setSelected(saved, false);
+    } else {
+      select.value = this.state.items[0].id;
+      this.setSelected(this.state.items[0].id, false);
+    }
+    let changeTimer;
+    select.addEventListener('change', e => {
+      const id = e.target.value;
+      clearTimeout(changeTimer);
+      changeTimer = setTimeout(() => {
+        localStorage.setItem('va-dashboard:selected', id);
+        this.setSelected(id);
+      }, 50);
+    });
+    this.startPolling();
+  }
+
+  async fetchData(url) {
+    const headers = {};
+    if (this.etag && url === this.dataUrl) headers['If-None-Match'] = this.etag;
+    const res = await fetch(url, { headers });
+    if (res.status === 304) return null;
+    if (!res.ok) throw new Error('status ' + res.status);
+    if (url === this.dataUrl) this.etag = res.headers.get('ETag');
+    return res.json();
+  }
+
+  async loadData() {
+    try {
+      const data = await this.fetchData(this.dataUrl);
+      if (data) {
+        this.state.items = data.items || [];
+        this.hideNotice();
+        this.setupSelect();
+        return;
+      }
+    } catch (e) {
+      // ignore and try fallback
+    }
+    try {
+      const data = await this.fetchData(this.fallbackUrl);
+      if (data) {
+        this.state.items = data.items || [];
+        this.showNotice('Offline—showing last known stats');
+        this.setupSelect();
+      }
+    } catch (e) {
+      this.showNotice('Offline—no data');
+    }
+  }
+
+  setupSelect() {
+    const select = this.root.querySelector('.va-dash__select');
+    select.innerHTML = '';
+    this.state.items.forEach(va => {
+      const opt = document.createElement('option');
+      opt.value = va.id;
+      opt.textContent = va.name;
+      select.appendChild(opt);
+    });
+  }
+
+  setSelected(id, animate = true) {
+    const va = this.state.items.find(i => i.id === id);
+    if (!va) return;
+    if (this.state.selectedId === id && animate) return; // no re-render
+    this.state.selectedId = id;
+    this.renderVA(va, animate);
+  }
+
+  renderVA(va, animate = true) {
+    // status
+    const statusDot = this.root.querySelector('.status-dot');
+    statusDot.classList.toggle('is-off', !va.online);
+    this.root.querySelector('.status-label').textContent = 'Updated just now';
+
+    // bubble
+    const bubble = this.root.querySelector('.va-dash__va-bubble');
+    bubble.querySelector('[data-va-name]').textContent = va.name;
+    bubble.classList.add('is-visible');
+
+    const rows = Array.from(this.root.querySelectorAll('.kpi'));
+    if (!animate) {
+      rows.forEach(li => {
+        const key = li.dataset.key;
+        const valEl = li.querySelector('[data-value]');
+        valEl.textContent = va.metrics[key] || 0;
+      });
+      return;
+    }
+    rows.forEach(li => li.classList.add('is-leaving'));
+    setTimeout(() => {
+      rows.forEach(li => {
+        li.classList.remove('is-leaving');
+        li.classList.add('is-entering');
+        const key = li.dataset.key;
+        const target = va.metrics[key] || 0;
+        const valEl = li.querySelector('[data-value]');
+        const current = parseInt(valEl.textContent, 10) || 0;
+        if (current !== target) this.animateValue(valEl, current, target);
+        requestAnimationFrame(() => li.classList.add('is-entered'));
+        li.addEventListener('transitionend', () => {
+          li.classList.remove('is-entering', 'is-entered');
+        }, { once: true });
+      });
+    }, 200);
+  }
+
+  animateValue(el, from, to, duration = 450) {
+    if (this.animations.has(el)) cancelAnimationFrame(this.animations.get(el));
+    const start = performance.now();
+    const step = now => {
+      const t = Math.min((now - start) / duration, 1);
+      const eased = 1 - Math.pow(1 - t, 3);
+      const value = Math.round(from + (to - from) * eased);
+      el.textContent = value;
+      if (t < 1) {
+        const raf = requestAnimationFrame(step);
+        this.animations.set(el, raf);
+      } else {
+        this.animations.delete(el);
+      }
+    };
+    const raf = requestAnimationFrame(step);
+    this.animations.set(el, raf);
+  }
+
+  startPolling() {
+    const poll = async () => {
+      if (document.visibilityState === 'hidden') {
+        this.pollTimer = setTimeout(poll, this.pollMs);
+        return;
+      }
+      try {
+        const data = await this.fetchData(this.dataUrl);
+        if (data) {
+          this.hideNotice();
+          this.state.items = data.items || [];
+          const current = this.state.items.find(i => i.id === this.state.selectedId);
+          if (current) this.renderVA(current, true);
+          this.pollMs = 60000; // reset
+        }
+      } catch (e) {
+        this.showNotice('Offline—showing last known stats');
+        this.pollMs = Math.min(this.pollMs * 2, 300000);
+      }
+      this.pollTimer = setTimeout(poll, this.pollMs);
+    };
+    poll();
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible' && !this.pollTimer) poll();
+    });
+  }
+
+  showNotice(msg) {
+    if (!this.noticeEl) return;
+    this.noticeEl.textContent = msg;
+    this.noticeEl.hidden = false;
+  }
+
+  hideNotice() {
+    if (!this.noticeEl) return;
+    this.noticeEl.hidden = true;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.va-dashboard').forEach(el => {
+    const dash = new VADashboard(el);
+    dash.init();
+  });
+});


### PR DESCRIPTION
## Summary
- add drop-in VA Dashboard HTML scaffold
- style dashboard with traffic lights, gold accents, and responsive layout
- implement vanilla JS widget with polling, animations, and offline handling
- include mock VA data sample

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b2693e5c6c832ba6dc7bba7546292d