### PR TITLE
Add vanilla VA dashboard widget

### DIFF
--- a/va-dashboard.css
+++ b/va-dashboard.css
@@ -1,0 +1,88 @@
+.va-dashboard {
+  --va-bg: #fff;
+  --va-text: #222;
+  --va-accent: #cfae70;
+  --va-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  --va-row-bg: #f7f7f7;
+  --va-row-border: #eee;
+  font-family: sans-serif;
+  width: 100%;
+  max-width: 320px;
+  background: var(--va-bg);
+  color: var(--va-text);
+  border-radius: 8px;
+  box-shadow: var(--va-shadow);
+  overflow: hidden;
+}
+.va-header {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem;
+  justify-content: space-between;
+}
+.traffic-dots {
+  display: flex;
+  gap: 4px;
+}
+.traffic-dots .dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+.dot.red { background: #ff5f56; }
+.dot.yellow { background: #ffbd2e; }
+.dot.green { background: #27c93f; }
+.va-select {
+  flex: 1;
+  margin-left: 0.5rem;
+}
+.va-status {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  padding: 0 0.75rem 0.5rem;
+}
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #bbb;
+}
+.status-dot.online { background: #27c93f; }
+.live-pill {
+  margin-left: auto;
+  background: var(--va-accent);
+  color: #000;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+}
+.va-metrics .metric-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background: var(--va-row-bg);
+  border-top: 1px solid var(--va-row-border);
+  transition: transform 0.2s, opacity 0.2s;
+}
+.va-metrics .metric-row:nth-child(odd) {
+  background: transparent;
+}
+.metric-row .value {
+  font-weight: bold;
+  text-align: right;
+}
+.metric-row .value.accent {
+  color: var(--va-accent);
+}
+.metric-row.updated {
+  transform: translateX(4px);
+  opacity: 0.7;
+}
+.offline {
+  text-align: center;
+  font-size: 0.75rem;
+  color: #b00;
+  padding: 0.25rem;
+}

--- a/va-dashboard.html
+++ b/va-dashboard.html
@@ -1,0 +1,32 @@
+<!-- VA Dashboard Widget -->
+<link rel="stylesheet" href="va-dashboard.css">
+<div class="va-dashboard" data-widget>
+  <div class="va-header">
+    <div class="traffic-dots" aria-hidden="true">
+      <span class="dot red"></span>
+      <span class="dot yellow"></span>
+      <span class="dot green"></span>
+    </div>
+    <select class="va-select" aria-label="Select virtual assistant"></select>
+  </div>
+  <div class="va-status">
+    <span class="status-dot"></span>
+    <span class="status-text">Updated just now</span>
+    <span class="live-pill" hidden>Live Now</span>
+  </div>
+  <div class="va-metrics" aria-live="polite">
+    <div class="metric-row">
+      <span class="label">Cold Calls Today</span>
+      <span class="value" data-metric="coldCallsToday">0</span>
+    </div>
+    <div class="metric-row">
+      <span class="label">Appointments Set</span>
+      <span class="value accent" data-metric="appointmentsSet">0</span>
+    </div>
+    <div class="metric-row">
+      <span class="label">Lists Processed</span>
+      <span class="value" data-metric="listsProcessed">0</span>
+    </div>
+  </div>
+</div>
+<script src="va-dashboard.js"></script>

--- a/va-dashboard.js
+++ b/va-dashboard.js
@@ -1,0 +1,146 @@
+(() => {
+  const POLL_INTERVAL = 60000;
+  const STORAGE_KEY = 'va-dashboard-selected';
+
+  const seedData = [
+    {
+      id: 'va1',
+      name: 'Alice',
+      online: true,
+      updatedAt: new Date().toISOString(),
+      coldCallsToday: 12,
+      appointmentsSet: 3,
+      listsProcessed: 5
+    },
+    {
+      id: 'va2',
+      name: 'Bob',
+      online: false,
+      updatedAt: new Date().toISOString(),
+      coldCallsToday: 8,
+      appointmentsSet: 2,
+      listsProcessed: 1
+    }
+  ];
+
+  const widget = document.querySelector('[data-widget]');
+  if (!widget) return;
+
+  const select = widget.querySelector('.va-select');
+  const statusDot = widget.querySelector('.status-dot');
+  const statusText = widget.querySelector('.status-text');
+  const livePill = widget.querySelector('.live-pill');
+  const metricsEl = widget.querySelector('.va-metrics');
+  const metricEls = {
+    coldCallsToday: metricsEl.querySelector('[data-metric="coldCallsToday"]'),
+    appointmentsSet: metricsEl.querySelector('[data-metric="appointmentsSet"]'),
+    listsProcessed: metricsEl.querySelector('[data-metric="listsProcessed"]')
+  };
+
+  let data = seedData;
+  let current;
+  let pollTimer;
+
+  function init() {
+    buildOptions();
+    select.addEventListener('change', () => {
+      localStorage.setItem(STORAGE_KEY, select.value);
+      render(true);
+    });
+    render(true);
+    fetchData();
+    startPolling();
+    document.addEventListener('visibilitychange', handleVisibility);
+  }
+
+  function buildOptions() {
+    select.innerHTML = '';
+    data.forEach(va => {
+      const opt = document.createElement('option');
+      opt.value = va.id;
+      opt.textContent = va.name;
+      select.appendChild(opt);
+    });
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored && data.some(v => v.id === stored)) {
+      select.value = stored;
+    }
+  }
+
+  function handleVisibility() {
+    if (document.hidden) {
+      clearInterval(pollTimer);
+    } else {
+      fetchData();
+      startPolling();
+    }
+  }
+
+  function startPolling() {
+    clearInterval(pollTimer);
+    pollTimer = setInterval(fetchData, POLL_INTERVAL);
+  }
+
+  async function fetchData() {
+    try {
+      const res = await fetch('/api/va-stats', { cache: 'no-store' });
+      if (!res.ok) throw new Error('Network');
+      const json = await res.json();
+      if (Array.isArray(json) && json.length) {
+        data = json;
+        buildOptions();
+        render();
+      }
+      widget.querySelector('.offline')?.remove();
+    } catch (e) {
+      if (!widget.querySelector('.offline')) {
+        const off = document.createElement('div');
+        off.className = 'offline';
+        off.textContent = 'Data unavailable';
+        widget.appendChild(off);
+      }
+    }
+  }
+
+  function render(force = false) {
+    current = data.find(v => v.id === select.value) || data[0];
+    if (!current) return;
+    statusDot.classList.toggle('online', current.online);
+    livePill.hidden = !current.online;
+    statusText.textContent = `Updated ${timeAgo(new Date(current.updatedAt))}`;
+    Object.entries(metricEls).forEach(([key, el]) => {
+      const newVal = current[key] || 0;
+      const prev = parseInt(el.textContent.replace(/,/g, '')) || 0;
+      if (force || newVal !== prev) {
+        animateNumber(el, prev, newVal);
+        const row = el.closest('.metric-row');
+        row.classList.add('updated');
+        setTimeout(() => row.classList.remove('updated'), 300);
+      }
+    });
+  }
+
+  function animateNumber(el, from, to) {
+    cancelAnimationFrame(el._raf);
+    const start = performance.now();
+    const dur = 500;
+    function frame(now) {
+      const progress = Math.min((now - start) / dur, 1);
+      const val = Math.round(from + (to - from) * progress);
+      el.textContent = val.toLocaleString();
+      if (progress < 1 && !document.hidden) {
+        el._raf = requestAnimationFrame(frame);
+      }
+    }
+    el._raf = requestAnimationFrame(frame);
+  }
+
+  function timeAgo(date) {
+    const diff = (Date.now() - date.getTime()) / 1000;
+    if (diff < 60) return 'just now';
+    const mins = Math.floor(diff / 60);
+    return `${mins}m ago`;
+  }
+
+  init();
+})();


### PR DESCRIPTION
## Summary
- build drop-in VA dashboard widget with white card, traffic lights, and KPI rows
- implement CSS variable theming, number tweening, and VA switcher
- fetch `/api/va-stats` with local JSON fallback and 60s polling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b26b5a6dc4832bbebf2275cf8f933b