### PR TITLE
Add dark mode color scheme

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -1,0 +1,37 @@
+/* Dark mode styles */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg1: #1c1f24;
+    --bg2: #1c1f24;
+    --va-navy: #1f2328;
+    --va-gold: #C3A35F;
+    --va-navy-contrast: #ffffff;
+    --va-gold-on-navy: #e5c97d;
+    --va-gold-strong: #d9b453;
+    --va-divider: #2a2d33;
+  }
+  body {
+    background-color: var(--bg1);
+    color: var(--va-navy-contrast);
+  }
+  .site-header {
+    background: rgba(31,35,40,0.96);
+    border-bottom-color: rgba(255,255,255,.08);
+  }
+  .nav a,
+  .nav button {
+    color: var(--va-navy-contrast);
+  }
+  .nav a:hover,
+  .nav button:hover {
+    color: var(--va-gold);
+  }
+  .card {
+    background: #272b34;
+    border-color: var(--va-divider);
+    color: inherit;
+  }
+  a {
+    color: var(--va-gold);
+  }
+}

--- a/index.html
+++ b/index.html
@@ -148,6 +148,7 @@
     <script data-template-id="country-code">window.__cf_country = "EG"</script>
         
     <link rel="stylesheet" href="cards.css?v=3">
+    <link rel="stylesheet" href="dark.css" media="(prefers-color-scheme: dark)">
     <style id="container-fix">
       .container {
         max-width: 100% !important;

--- a/offline.html
+++ b/offline.html
@@ -4,7 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' https: data:;">
+  <meta name="color-scheme" content="light dark">
   <title>Offline</title>
+  <link rel="stylesheet" href="dark.css" media="(prefers-color-scheme: dark)">
   <style>
     body { font-family: sans-serif; text-align: center; padding: 2rem; }
   </style>


### PR DESCRIPTION
## Summary
- add CSS variables and component overrides for dark theme
- load dark-mode styles in main and offline pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b311f35dfc832b9b71ff644b77904e