### PR TITLE
Add mobile-only Book button

### DIFF
--- a/css/va-custom.css
+++ b/css/va-custom.css
@@ -1,4 +1,4 @@
-#mobile-book-btn {
+#book-btn {
   position: fixed;
   bottom: 1rem;
   right: 1rem;
@@ -13,12 +13,6 @@
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
 }
 
-#mobile-book-btn:hover {
+#book-btn:hover {
   opacity: 0.9;
-}
-
-@media (min-width: 768px) {
-  #mobile-book-btn {
-    display: none;
-  }
 }

--- a/css/va-custom.css
+++ b/css/va-custom.css
@@ -1,0 +1,24 @@
+#mobile-book-btn {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 1000;
+  display: block;
+  padding: 0.75rem 1rem;
+  background-color: #082541;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+#mobile-book-btn:hover {
+  opacity: 0.9;
+}
+
+@media (min-width: 768px) {
+  #mobile-book-btn {
+    display: none;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -320,6 +320,6 @@
 })();
 </script>
 
-<a href="https://calendly.com/youssef-vahorizon/30min" id="mobile-book-btn">Book Now</a>
+<a href="https://calendly.com/youssef-vahorizon/30min" id="book-btn">Book Now</a>
 
 </body></html>

--- a/index.html
+++ b/index.html
@@ -148,6 +148,7 @@
     <script data-template-id="country-code">window.__cf_country = "EG"</script>
         
     <link rel="stylesheet" href="cards.css?v=3">
+    <link rel="stylesheet" href="css/va-custom.css">
     <style id="container-fix">
       .container {
         max-width: 100% !important;
@@ -318,5 +319,7 @@
   map.forEach((_, section) => io.observe(section));
 })();
 </script>
+
+<a href="https://calendly.com/youssef-vahorizon/30min" id="mobile-book-btn">Book Now</a>
 
 </body></html>


### PR DESCRIPTION
## Summary
- add custom stylesheet for mobile-only Book Now button
- include Book Now button on page linking to Calendly scheduling page

## Testing
- `npx stylelint css/va-custom.css`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b3a3091e14832bbdeb61616e9af8ef