### PR TITLE
Add sitemap for public pages

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.vahorizon.site/</loc>
+  </url>
+  <url>
+    <loc>https://www.vahorizon.site/leadgen/</loc>
+  </url>
+  <url>
+    <loc>https://www.vahorizon.site/partner/</loc>
+  </url>
+  <url>
+    <loc>https://www.vahorizon.site/offline.html</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add a sitemap listing the main marketing and lead pages
- ensure sitemap URL matches the robots.txt reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68c8bab85f508332b26ade1b2e2cf69d