### PR TITLE
Add canonical and social metadata to leadgen and partner pages

### DIFF
--- a/leadgen/index.html
+++ b/leadgen/index.html
@@ -3,8 +3,19 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>VA Horizon — Lead Generator (Commission-Based)</title>
-  <meta name="description" content="Commission-based Lead Generator role at VA Horizon: educate real estate wholesalers, send them our website, and book appointments." />
+  <title>VA Horizon Lead Generator — Commission-Based Real Estate VA Role</title>
+  <meta name="description" content="Apply for VA Horizon's commission-based lead generator role: educate real estate wholesalers, showcase our trained virtual assistants, and book qualified Calendly appointments." />
+  <link rel="canonical" href="https://www.vahorizon.site/leadgen/">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="VA Horizon Lead Generator — Commission-Based Real Estate VA Role">
+  <meta property="og:description" content="Apply for VA Horizon's commission-based lead generator role: educate real estate wholesalers, showcase our trained virtual assistants, and book qualified Calendly appointments.">
+  <meta property="og:url" content="https://www.vahorizon.site/leadgen/">
+  <meta property="og:image" content="https://www.vahorizon.site/social/va-horizon-og.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="VA Horizon Lead Generator — Commission-Based Real Estate VA Role">
+  <meta name="twitter:description" content="Apply for VA Horizon's commission-based lead generator role: educate real estate wholesalers, showcase our trained virtual assistants, and book qualified Calendly appointments.">
+  <meta name="twitter:url" content="https://www.vahorizon.site/leadgen/">
+  <meta name="twitter:image" content="https://www.vahorizon.site/social/va-horizon-og.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/partner/index.html
+++ b/partner/index.html
@@ -3,8 +3,19 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>VA Horizon • Referral / Partner Program</title>
-  <meta name="description" content="Earn 30% in month one + 10% for the next 3 months by referring wholesalers to VA Horizon's trained Virtual Assistants for wholesalers & investors." />
+  <title>VA Horizon Referral Partner Program — Earn 30% + 10% on VA Placements</title>
+  <meta name="description" content="Join the VA Horizon referral partner program to earn 30% in month one and 10% for the next 3 months by introducing real estate wholesalers to our trained virtual assistants." />
+  <link rel="canonical" href="https://www.vahorizon.site/partner/">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="VA Horizon Referral Partner Program — Earn 30% + 10% on VA Placements">
+  <meta property="og:description" content="Join the VA Horizon referral partner program to earn 30% in month one and 10% for the next 3 months by introducing real estate wholesalers to our trained virtual assistants.">
+  <meta property="og:url" content="https://www.vahorizon.site/partner/">
+  <meta property="og:image" content="https://www.vahorizon.site/social/va-horizon-og.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="VA Horizon Referral Partner Program — Earn 30% + 10% on VA Placements">
+  <meta name="twitter:description" content="Join the VA Horizon referral partner program to earn 30% in month one and 10% for the next 3 months by introducing real estate wholesalers to our trained virtual assistants.">
+  <meta name="twitter:url" content="https://www.vahorizon.site/partner/">
+  <meta name="twitter:image" content="https://www.vahorizon.site/social/va-horizon-og.png">
   <meta name="theme-color" content="#111317" />
   <style>
     :root{


### PR DESCRIPTION
## Summary
- add canonical URLs and Open Graph/Twitter metadata to the lead generator landing page
- update the partner program page with canonical link and social sharing tags while refining title/description copy

## Testing
- npm run lint:html

------
https://chatgpt.com/codex/tasks/task_b_68c8bc36bf5083329f27d01f4c22c30d