### PR TITLE
Add structured data for job posting and partner FAQ

### DIFF
--- a/leadgen/index.html
+++ b/leadgen/index.html
@@ -394,15 +394,43 @@
   {
     "@context": "https://schema.org",
     "@type": "JobPosting",
-    "title": "Lead Generator (Commission-Based)",
-    "hiringOrganization": { "@type": "Organization", "name": "VA Horizon", "sameAs": "https://vahorizon.site" },
+    "title": "Commission-Based Lead Generator",
+    "description": "Commission-based lead generation role supporting VA Horizon's virtual assistant placements for real estate wholesalers. Educate prospects on our services, confirm they reviewed vahorizon.site, and schedule Calendly calls for the sales team.",
+    "datePosted": "2025-09-16",
     "employmentType": "CONTRACTOR",
+    "hiringOrganization": {
+      "@type": "Organization",
+      "name": "VA Horizon",
+      "url": "https://www.vahorizon.site",
+      "sameAs": ["https://www.vahorizon.site"],
+      "logo": "https://www.vahorizon.site/logo.png"
+    },
     "jobLocationType": "TELECOMMUTE",
-    "applicantLocationRequirements": {"@type":"Country","name":"Remote"},
-    "description": "Find wholesalers, send them vahorizon.site and require they view it, ask the qualifying question, and book them to our Calendly. $10 per qualified lead, $1 referral bonus. Biweekly payouts on the 5th & 20th.",
-    "incentiveCompensation": "$10 per qualified lead; $1 per qualified lead from referrals",
+    "applicantLocationRequirements": {
+      "@type": "AdministrativeArea",
+      "name": "Remote (worldwide)"
+    },
     "industry": "Real Estate",
-    "validThrough": "2099-12-31T23:59:59"
+    "occupationalCategory": "Sales and Related Occupations",
+    "responsibilities": "Find and qualify real estate wholesalers, share vahorizon.site, confirm interest, and book Calendly appointments for the VA Horizon team.",
+    "qualifications": "Strong written communication and experience with outbound social or SMS outreach. Comfortable following a repeatable script and documenting conversations.",
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "USD",
+      "value": {
+        "@type": "QuantitativeValue",
+        "value": 10,
+        "unitText": "EACH"
+      }
+    },
+    "incentiveCompensation": "$10 per qualified lead plus $1 per qualified referral lead.",
+    "workHours": "Flexible scheduling based on your outreach availability.",
+    "applicationContact": {
+      "@type": "ContactPoint",
+      "contactType": "Apply",
+      "email": "Youssef@vahorizon.site"
+    },
+    "validThrough": "2025-12-31T23:59:00-05:00"
   }
   </script>
 

--- a/partner/index.html
+++ b/partner/index.html
@@ -198,6 +198,55 @@
     </div>
   </footer>
 
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What exactly do I earn?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "You earn 30% of the client's first month once they start, plus 10% for the next three months on active subscriptions."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do you know I referred them?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Referrals are credited when the client names you on the booking form or you email us their details after the intro, and we also support unique tracking links."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "When do I get paid?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Payouts are processed on a net-30 schedule after the client's invoice is paid for the applicable month."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Do you have a minimum payout?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes, there is a $100 minimum and balances roll over until the threshold is met."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Any rules on promotion?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Partners must be truthful, comply with disclosure rules, and avoid brand-term bidding or misleading incentives when promoting the program."
+        }
+      }
+    ]
+  }
+  </script>
+
   <script>document.getElementById('y').textContent = new Date().getFullYear();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update the lead generation landing page with a detailed JobPosting JSON-LD block covering the role, remote setup, compensation, and employer details
- add FAQPage structured data to the partner referral page so common payout and attribution questions are exposed to search engines

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_b_68c8bd0b7f9483328955b2aa4d919909