### PR TITLE
Update alt text for leadgen and partner images

### DIFF
--- a/leadgen/index.html
+++ b/leadgen/index.html
@@ -153,7 +153,7 @@
   <div class="topbar">
     <div class="nav">
       <div class="brand">
-        <img src="https://www.vahorizon.site/logo.png" alt="VA Horizon logo placeholder">
+        <img src="https://www.vahorizon.site/logo.png" alt="VA Horizon logo">
         <div class="title">
           <b>VA HORIZON</b>
           <span class="subtitle">TRAINED VIRTUAL ASSISTANTS</span>
@@ -375,7 +375,7 @@
   <footer>
     <div class="footer-inner">
       <div style="display:flex; align-items:center; gap:12px;">
-        <img src="https://www.vahorizon.site/logo.png" alt="VA Horizon mark placeholder" />
+        <img src="https://www.vahorizon.site/logo.png" alt="VA Horizon logo" />
         <div>
           <div>© <span id="yr"></span> VA Horizon</div>
           <div class="muted">Virtual Assistants for Real Estate Wholesalers</div>

--- a/partner/index.html
+++ b/partner/index.html
@@ -85,7 +85,7 @@
           </div>
         </div>
         <div class="card">
-          <a href="https://vahorizon.site"><img src="https://i.ibb.co/Jwn9WQX1/Gold-on-Charcoal-Premium-Look1.png" alt="Gold-on-Charcoal-Premium-Look1" border="0"></a>
+          <a href="https://vahorizon.site"><img src="https://i.ibb.co/Jwn9WQX1/Gold-on-Charcoal-Premium-Look1.png" alt="VA Horizon gold partner badge" border="0"></a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- replace placeholder logo alt text in the leadgen page with descriptive wording
- update the partner hero badge image to use a descriptive alt value

## Testing
- npm run lint:html

------
https://chatgpt.com/codex/tasks/task_b_68c8befe82f483328b8800746d17403f