### PR TITLE
Add lazy loading to below-the-fold images

### DIFF
--- a/leadgen/index.html
+++ b/leadgen/index.html
@@ -375,7 +375,7 @@
   <footer>
     <div class="footer-inner">
       <div style="display:flex; align-items:center; gap:12px;">
-        <img src="https://www.vahorizon.site/logo.png" alt="VA Horizon logo" />
+        <img src="https://www.vahorizon.site/logo.png" alt="VA Horizon logo" loading="lazy" />
         <div>
           <div>© <span id="yr"></span> VA Horizon</div>
           <div class="muted">Virtual Assistants for Real Estate Wholesalers</div>

--- a/partner/index.html
+++ b/partner/index.html
@@ -85,7 +85,7 @@
           </div>
         </div>
         <div class="card">
-          <a href="https://vahorizon.site"><img src="https://i.ibb.co/Jwn9WQX1/Gold-on-Charcoal-Premium-Look1.png" alt="VA Horizon gold partner badge" border="0"></a>
+          <a href="https://vahorizon.site"><img src="https://i.ibb.co/Jwn9WQX1/Gold-on-Charcoal-Premium-Look1.png" alt="VA Horizon gold partner badge" border="0" loading="lazy"></a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add native lazy loading to the lead generation footer logo
- defer loading of the partner program badge image until it is needed

## Testing
- python - <<'PY'  # Playwright cross-browser lazy loading verification


------
https://chatgpt.com/codex/tasks/task_b_68c8c5c8f22483329477b6046fbc7ff9