### PR TITLE
Add noindex meta tag to offline offline page

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' https: data:; media-src 'self';">
   <title>Offline</title>
   <style>


### PR DESCRIPTION
## Summary
- add a robots noindex meta tag to the offline page so search engines do not index it

## Testing
- curl http://127.0.0.1:8000/offline.html

------
https://chatgpt.com/codex/tasks/task_b_68c8cbf9803c8332b5399e301d7fe416