### PR TITLE
Add Open Graph metadata to leadgen and partner pages

### DIFF
--- a/leadgen/index.html
+++ b/leadgen/index.html
@@ -10,6 +10,8 @@
   <meta property="og:title" content="VA Horizon Lead Generator — Commission-Based Real Estate VA Role">
   <meta property="og:description" content="Apply for VA Horizon's commission-based lead generator role: educate real estate wholesalers, showcase our trained virtual assistants, and book qualified Calendly appointments.">
   <meta property="og:url" content="https://www.vahorizon.site/leadgen/">
+  <meta property="og:site_name" content="VA Horizon">
+  <meta property="og:locale" content="en_US">
   <meta property="og:image" content="https://www.vahorizon.site/social/va-horizon-og.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="VA Horizon Lead Generator — Commission-Based Real Estate VA Role">

--- a/partner/index.html
+++ b/partner/index.html
@@ -10,6 +10,8 @@
   <meta property="og:title" content="VA Horizon Referral Partner Program — Earn 30% + 10% on VA Placements">
   <meta property="og:description" content="Join the VA Horizon referral partner program to earn 30% in month one and 10% for the next 3 months by introducing real estate wholesalers to our trained virtual assistants.">
   <meta property="og:url" content="https://www.vahorizon.site/partner/">
+  <meta property="og:site_name" content="VA Horizon">
+  <meta property="og:locale" content="en_US">
   <meta property="og:image" content="https://www.vahorizon.site/social/va-horizon-og.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="VA Horizon Referral Partner Program — Earn 30% + 10% on VA Placements">


### PR DESCRIPTION
## Summary
- add Open Graph site name and locale metadata to the lead generation landing page
- add the same Open Graph metadata to the partner program landing page for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68c8cc80d570833291dbb69ea4d0fe89