### PR TITLE
Allow FormSubmit in CSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
       </style>
     </noscript>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' https: data:; media-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' https: data:; media-src 'self'; form-action 'self' https://formsubmit.co;">
     <meta name="color-scheme" content="light dark">
     <link rel="canonical" href="https://www.vahorizon.site/">
 

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,4 +1,4 @@
-add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' https: data:; media-src 'self';" always;
+add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' https: data:; media-src 'self'; form-action 'self' https://formsubmit.co;" always;
 add_header X-Content-Type-Options nosniff always;
 add_header Referrer-Policy strict-origin-when-cross-origin always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;


### PR DESCRIPTION
## Summary
- allow the FormSubmit endpoint in the document Content-Security-Policy
- mirror the form-action directive in the security headers configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c8d24160b8833283debb63ac109006